### PR TITLE
[FIX] Fixed automatic build for drepl on recent versions of DUB

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -11,7 +11,7 @@ configuration "lib" {
 }
 configuration "vendored" {
     targetType "sourceLibrary"
-    preBuildCommands "cd $PACKAGE_DIR; [ -f C/linenoise.o ] || cc -c -fPIC -o C/linenoise.o C/linenoise.c" platform="posix"
+    preBuildCommands "cd $LINENOISE_PACKAGE_DIR; [ -f C/linenoise.o ] || cc -c -fPIC -o C/linenoise.o C/linenoise.c" platform="posix"
     sourceFiles "C/linenoise.o" platform="posix"
 }
 configuration "example" {


### PR DESCRIPTION
See: https://github.com/dlang-community/drepl/issues/91

Also, possibly it is DUB bug, that provides incorrect value for $PACKAGE_DIR variable.